### PR TITLE
Add `aiohttp` run requirement

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ build:
     - euporie-hub = euporie.hub.__main__:main
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - hatchling
     - pip
   run:
+    - aiohttp >=3.9,<4.dev0
     - typing_extensions >=4.5,<5.dev0
     - jupytext >=1.14.0
     - python >={{ python_min }}


### PR DESCRIPTION
This PR adds [`aiohttp`](https://github.com/aio-libs/aiohttp) as a runtime requirement for `euporie`. Without this addition, running `euporie` in a Conda environment or a Pixi global installation results in the following error:

```
Traceback (most recent call last):
  File "/Users/apcamargo/.pixi/envs/euporie/bin/euporie-preview", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/apcamargo/.pixi/envs/euporie/lib/python3.12/site-packages/euporie/preview/__main__.py", line 10, in main
    __main__.main(str(sys.modules[__name__].__package__).rpartition(".")[2])
  File "/Users/apcamargo/.pixi/envs/euporie/lib/python3.12/site-packages/euporie/core/__main__.py", line 32, in main
    from euporie.core import (
  File "/Users/apcamargo/.pixi/envs/euporie/lib/python3.12/site-packages/euporie/core/path.py", line 10, in <module>
    from aiohttp.client_reqrep import ClientResponse
ModuleNotFoundError: No module named 'aiohttp'
```

A standard `pip` installation works correctly, but the reason for this discrepancy is unclear since `aiohttp` is not explicitly listed as a dependency in `euporie`’s project. Perhaps @joouha can provide some insight.

The dependency tree is as follows:

```
$ uv init euporie-test
$ cd euporie-test
$ uv add euporie
$ uv pip tree

aiohttp v3.11.14
├── aiohappyeyeballs v2.6.1
├── aiosignal v1.3.2
│   └── frozenlist v1.5.0
├── attrs v25.3.0
├── frozenlist v1.5.0
├── multidict v6.2.0
├── propcache v0.3.1
└── yarl v1.18.3
    ├── idna v3.10
    ├── multidict v6.2.0
    └── propcache v0.3.1
euporie v2.8.8
├── fastjsonschema v2.21.1
├── flatlatex v0.15
│   └── regex v2024.11.6
├── fsspec v2025.3.0
├── imagesize v1.4.1
├── jupyter-client v8.6.3
│   ├── jupyter-core v5.7.2
│   │   ├── platformdirs v3.11.0
│   │   └── traitlets v5.14.3
│   ├── python-dateutil v2.9.0.post0
│   │   └── six v1.17.0
│   ├── pyzmq v26.3.0
│   ├── tornado v6.4.2
│   └── traitlets v5.14.3
├── jupytext v1.16.7
│   ├── markdown-it-py v3.0.0
│   │   └── mdurl v0.1.2
│   ├── mdit-py-plugins v0.4.2
│   │   └── markdown-it-py v3.0.0 (*)
│   ├── nbformat v5.10.4
│   │   ├── fastjsonschema v2.21.1
│   │   ├── jsonschema v4.23.0
│   │   │   ├── attrs v25.3.0
│   │   │   ├── jsonschema-specifications v2024.10.1
│   │   │   │   └── referencing v0.36.2
│   │   │   │       ├── attrs v25.3.0
│   │   │   │       └── rpds-py v0.23.1
│   │   │   ├── referencing v0.36.2 (*)
│   │   │   └── rpds-py v0.23.1
│   │   ├── jupyter-core v5.7.2 (*)
│   │   └── traitlets v5.14.3
│   ├── packaging v24.2
│   └── pyyaml v6.0.2
├── linkify-it-py v2.0.3
│   └── uc-micro-py v1.0.3
├── markdown-it-py v3.0.0 (*)
├── mdit-py-plugins v0.4.2 (*)
├── nbformat v5.10.4 (*)
├── pillow v11.1.0
├── platformdirs v3.11.0
├── prompt-toolkit v3.0.50
│   └── wcwidth v0.2.13
├── pygments v2.19.1
├── pyperclip v1.9.0
├── sixelcrop v0.1.9
├── timg v1.1.6
│   └── pillow v11.1.0
├── typing-extensions v4.13.0
└── universal-pathlib v0.2.6
    └── fsspec v2025.3.0
```

For some reason, `aiohttp` does not appear as a dependency of `euporie`, but as a separate package. However, it is listed as a requirement in the [AUR package](https://aur.archlinux.org/packages/euporie?all_deps=1#pkgdeps).

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
